### PR TITLE
Remove create_zero address from address factory

### DIFF
--- a/sdk-core/address.md
+++ b/sdk-core/address.md
@@ -50,10 +50,6 @@ print("Public key (hex-encoded):", address.hex())
 class AddressFactory:
     constructor(hrp: string = "erd");
 
-    // Creates an address with all bytes set to zero.
-    // This is the same as the "contract deployment address".
-    create_zero(): Address;
-
     // Creates an address from a bech32 string.
     create_from_bech32(value: string): Address;
 


### PR DESCRIPTION
As stated in [this issue](https://github.com/multiversx/mx-sdk-specs/issues/21), since the **zero address** is only used for contract deployment and we have a factory that takes care of this, there is no need to create the **zero address**.