### PR TITLE
Include original query in smart contract query response

### DIFF
--- a/sdk-core/smart_contract_query.md
+++ b/sdk-core/smart_contract_query.md
@@ -13,7 +13,7 @@ dto SmartContractQuery:
 
 ```
 dto SmartContractQueryResponse:
-    original_query?: SmartContractQuery;
+    original_query_function: string;
     return_code: string;
     return_message: string;
     return_data_parts: List[bytes];

--- a/sdk-core/smart_contract_query.md
+++ b/sdk-core/smart_contract_query.md
@@ -13,6 +13,7 @@ dto SmartContractQuery:
 
 ```
 dto SmartContractQueryResponse:
+    original_query?: SmartContractQuery;
     return_code: string;
     return_message: string;
     return_data_parts: List[bytes];

--- a/sdk-core/smart_contract_query.md
+++ b/sdk-core/smart_contract_query.md
@@ -13,7 +13,7 @@ dto SmartContractQuery:
 
 ```
 dto SmartContractQueryResponse:
-    original_query_function: string;
+    function: string;
     return_code: string;
     return_message: string;
     return_data_parts: List[bytes];


### PR DESCRIPTION
Necessary to recover the function called by the query, to enable ABI-informed decoding.