### PR TITLE
Fix return type of delegation transaction parser

### DIFF
--- a/core/transaction.md
+++ b/core/transaction.md
@@ -47,7 +47,7 @@ class TransactionComputer:
 
     // this method should take care of both "regular" transaction signing and hash signing.
     // should serialize the transaction after checking the version and the options fields.
-    // if version == 2 and the least significant bit of the options field is set it should serialize the transaction without the `signature` and `guardianSignature` fields and compute it's hash
+    // if version >= 2 and the least significant bit of the options field is set it should serialize the transaction without the `signature` and `guardianSignature` fields and compute it's hash
     // if the least significant bit is not set should simply serialize the transaction the "regular" way
     // should also validate if the some of the transaction fields are set (sender, receiver, gasLimit, chainId); throws error otherwise
     compute_bytes_for_signing(transaction: Transaction): bytes;
@@ -57,7 +57,7 @@ class TransactionComputer:
     // returns True if the second least significant bit is set; returns False otherwise
     has_options_set_for_guarded_transaction(transaction: Transaction): bool;
 
-    // returns True if the least significant bit is set; returns False otherwise; should also have transaction.version == 2
+    // returns True if the least significant bit is set; returns False otherwise; should also have transaction.version >= 2
     has_options_set_for_hash_signing(transaction: Transacion): bool;
 
     // sets guardian address, transaction.version = 2, sets transaction.options second least significant bit

--- a/core/transaction.md
+++ b/core/transaction.md
@@ -45,6 +45,11 @@ dto DraftTransaction:
 class TransactionComputer:
     compute_transaction_fee(transaction: Transaction, network_config: INetworkConfig): Amount;
 
+    // this method should take care of both "regular" transaction signing and hash signing.
+    // should serialize the transaction after checking the version and the options fields.
+    // if version == 2 and the least significant bit of the options field is set it should serialize the transaction without the `signature` and `guardianSignature` fields and compute it's hash
+    // if the least significant bit is not set should simply serialize the transaction the "regular" way
+    // should also validate if the some of the transaction fields are set (sender, receiver, gasLimit, chainId); throws error otherwise
     compute_bytes_for_signing(transaction: Transaction): bytes;
 
     compute_transaction_hash(transaction: Transaction): bytes;
@@ -52,7 +57,7 @@ class TransactionComputer:
     // returns True if the second least significant bit is set; returns False otherwise
     has_options_set_for_guarded_transaction(transaction: Transaction): bool;
 
-    // returns True if the least significant bit is set; returns False otherwise
+    // returns True if the least significant bit is set; returns False otherwise; should also have transaction.version == 2
     has_options_set_for_hash_signing(transaction: Transacion): bool;
 
     // sets guardian address, transaction.version = 2, sets transaction.options second least significant bit

--- a/core/transaction.md
+++ b/core/transaction.md
@@ -47,7 +47,7 @@ class TransactionComputer:
 
     // this method should take care of both "regular" transaction signing and hash signing.
     // should serialize the transaction after checking the version and the options fields.
-    // if version >= 2 and the least significant bit of the options field is set it should serialize the transaction without the `signature` and `guardianSignature` fields and compute it's hash
+    // if version >= 2 and the least significant bit of the options field is set it should serialize the transaction and compute its hash
     // if the least significant bit is not set should simply serialize the transaction the "regular" way
     // should also validate if the some of the transaction fields are set (sender, receiver, gasLimit, chainId); throws error otherwise
     compute_bytes_for_signing(transaction: Transaction): bytes;

--- a/core/transactions-outcome-parsers/delegation_transactions_outcome_parser.md
+++ b/core/transactions-outcome-parsers/delegation_transactions_outcome_parser.md
@@ -5,7 +5,7 @@ i.e. Getting the address of a newly created delgation contract.
 
 Each method should ensure that there is no `signalError` event.
 
-For all methods that return something, plain objects(JS) or simple DTOs(Py) can be used.
+For all methods that return something, arrays of plain objects(JS) or simple DTOs(Py) can be used.
 For DTOs, a naming convention should be used. Something like the name of the operation followed by the `Outcome` keyword.
 
 e.g.
@@ -19,5 +19,5 @@ dto CreateNewDelegationContractOutcome:
 class DelegationTransactionsOutcomeParser:
     parse_create_new_delegation_contract(transaction_outcome: TransactionOutcome): {
         contract_address: string;
-    };
+    }[];
 ```


### PR DESCRIPTION
Fixed the return type of the delegation transactions outcome parser.

Also specified how the `compute_bytes_for_signing()` method should work. It it should serialize the transaction for `hash signing` or regular transaction signing.