### PR TITLE
Data field as bytes for native token transfer

### DIFF
--- a/core/transactions-factories/transfer_transactions_factory.md
+++ b/core/transactions-factories/transfer_transactions_factory.md
@@ -12,6 +12,7 @@ class TransferTransactionsFactory:
         sender: IAddress;
         receiver: IAddress;
         native_amount: Amount;
+        data: Optional[bytes];
     }): Transaction;
 
     // Can throw:


### PR DESCRIPTION
The field was missing from the specs, but it was already present in the sdks. It use to be of type `string` but it's better to be of type `bytes`.