### PR TITLE
Added ESDTTransferRole on fungible token

### DIFF
--- a/core/transactions-factories/token_management_transactions_factory.md
+++ b/core/transactions-factories/token_management_transactions_factory.md
@@ -86,6 +86,7 @@ class TokenManagementTransactionsFactory:
         tokenIdentifier: string;
         addRoleLocalMint: boolean;
         addRoleLocalBurn: boolean;
+        addRoleESDTTransferRole: boolean;
     }): Transaction;
 
     create_transaction_for_setting_special_role_on_semi_fungible_token({


### PR DESCRIPTION
The `ESDTTransferRole` was missing when setting special roles on fungible tokens.