### PR TITLE
Adjust design guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ One controller is backed by **one transaction factory and one outcome parser** (
 
 Generally speaking, it's recommended to receive input parameters as abstractions (interfaces) in the public API of the SDKs. This leads to an improved decoupling, and allows for easier type substitution (e.g. easier mocking, testing).
 
+Exception to the rule above: when receiving easily constructable objects (plain structures, DTOs) as input parameters, it's perfectly fine to receive them as concrete types.
+
 Generally speaking, it's recommended to return concrete types in the public API of the SDKs. The client code is responsible with decoupling from unnecessary data and behaviour of returned objects (e.g. by using interfaces, on their side). The only notable exception to this is when working with factories (abstract or method factories) that should have the function output an interface type. For example, have a look over `(User|Validator)WalletProvider.generate_keypair()` - this method returns abstract types (interfaces).
 
 ### **`pay-attention-to-types`**


### PR DESCRIPTION
**(a) Simplicity and Clarity:** Passing DTOs as concrete types can simplify the API, making it more straightforward for developers to use. If the DTOs are simple, immutable objects without behavior, the need for interfaces may be over-engineering.

**(b) Ease of Use:** Using concrete types can make the API easier to understand and work with, as developers don't have to worry about implementing or knowing multiple interfaces.

**(c) Testing:** Interfaces can make unit testing easier by allowing the use of mocks or stubs. However, if the DTOs are very simple and do not require complex behavior, this might not be a significant advantage.

Though:

**(d) Flexibility and Extensibility:** The trade-off is in flexibility. If some DTOs are likely to change or if different implementations are needed in the future, sticking with interfaces could be beneficial. Interfaces allow for easier swapping of different implementations.