### PR TITLE
"TokenTransfer" is an alias of "TokenAmount" (and both are DTOs)

### DIFF
--- a/core/tokens.md
+++ b/core/tokens.md
@@ -62,15 +62,13 @@ dto TokenIdentifierParts:
 This is a synonym for `TokenAmount`.
 
 ```
-dto TokenTransfer implements ITokenAmount:
-    token: Token;
-    amount: Amount;
+dto TokenTransfer = TokenAmount;
 ```
 
-## ITokenAmount
+## TokenAmount
 
 ```
-interface ITokenAmount:
+dto TokenAmount:
     token: Token;
 
     // Always in atomic units, e.g. for expressing 1.000000 "USDC-c76f1f", it must be "1000000".

--- a/core/transactions-factories/smart_contract_transactions_factory.md
+++ b/core/transactions-factories/smart_contract_transactions_factory.md
@@ -26,7 +26,7 @@ class SmartContractTransactionsFactory:
         function: string;
         arguments: List[object] = [];
         native_transfer_amount: Amount = 0;
-        token_transfers: List[ITokenAmount] = [];
+        token_transfers: List[TokenAmount] = [];
         gasLimit: uint32;
     }): Transaction;
 

--- a/core/transactions-factories/transfer_transactions_factory.md
+++ b/core/transactions-factories/transfer_transactions_factory.md
@@ -32,6 +32,6 @@ class TransferTransactionsFactory:
     create_transaction_for_esdt_token_transfer({
         sender: IAddress;
         receiver: IAddress;
-        token_transfers: ITokenAmount[];
+        token_transfers: TokenAmount[];
     }): Transaction;
 ```


### PR DESCRIPTION
 - `TokenTransfer` is an alias of `TokenAmount` (both are DTOs).
 - We should consider `TokenAmount` as the more important class, and `TokenTransfer` as a mere alias. Reason: `TokenAmount` is also usable for representing amounts that are being _held_ by an account, not only _amounts being transferred_ (name is more inclusive).