### PR TITLE
Address instead of string / IAddress

### DIFF
--- a/core/address.md
+++ b/core/address.md
@@ -78,22 +78,8 @@ class AddressComputer:
     // The constructor is not captured by the specs; it's up to the implementing library to define it.
 
     // Note that the first input parameter is received as an interface, but the return value is a concrete type (see guidelines).
-    compute_contract_address(deployer: IAddress, deployment_nonce: number): Address;
+    compute_contract_address(deployer: Address, deployment_nonce: number): Address;
 
     // The number of shards (necessary for computing the shard ID) would be received as a constructor parameter - constructor is not captured by specs.
-    get_shard_of_address(address: IAddress): number;
-```
-
-Above, `IAddress` should satisfy:
-
-```
-get_public_key(): bytes;
-get_hrp(): string;
-```
-
-OR, perhaps, it should simply satisfy:
-
-```
-// Name should be adjusted to match the language's convention.
-to_bech32(): string;
+    get_shard_of_address(address: Address): number;
 ```

--- a/core/controllers/smart_contract_controller.md
+++ b/core/controllers/smart_contract_controller.md
@@ -45,7 +45,7 @@ class SmartContractController:
     create_transaction_for_upgrade({
         sender: IAccount;
         nonce: Optional[int];
-        contract: IAddress;
+        contract: Address;
         bytecode: bytes OR bytecodePath: Path;
         arguments: List[object] = [];
         native_transfer_amount: Amount = 0;
@@ -80,7 +80,7 @@ class SmartContractController:
     create_transaction_for_execute({
         sender: IAccount;
         nonce: Optional[int];
-        contract: IAddress;
+        contract: Address;
         // If "function" is a reserved word in the implementing language, it should be replaced with a different name (e.g. "func" or "functionName").
         function: string;
         arguments: List[object] = [];
@@ -108,8 +108,8 @@ class SmartContractController:
     };
 
     query_contract({
-        contract: IAddress;
-        caller?: IAddress;
+        contract: Address;
+        caller?: Address;
         value?: Amount;
         function: string;
         arguments: List[object];

--- a/core/message.md
+++ b/core/message.md
@@ -4,7 +4,7 @@
 dto Message:
     data: bytes;
     signature: bytes;
-    address: IAddress;
+    address: Address;
     version: int;
     signer: string;
 ```

--- a/core/smart_contract_queries_controller.md
+++ b/core/smart_contract_queries_controller.md
@@ -10,8 +10,8 @@ class SmartContractQueriesController:
     // Can throw:
     // - ErrSmartContractQuery (e.g. when return code is not "ok")
     query({
-        contract: IAddress;
-        caller?: IAddress;
+        contract: Address;
+        caller?: Address;
         value?: Amount;
         function: string;
         arguments: List[object];

--- a/core/smart_contract_query.md
+++ b/core/smart_contract_query.md
@@ -2,7 +2,7 @@
 
 ```
 dto SmartContractQuery:
-    contract: string;
+    contract: Address;
     caller?: string;
     value?: Amount;
     function: string;

--- a/core/transaction.md
+++ b/core/transaction.md
@@ -2,8 +2,8 @@
 
 ```
 dto Transaction:
-    sender: string;
-    receiver: string;
+    sender: Address;
+    receiver: Address;
     gasLimit: uint32;
     chainID: string;
 
@@ -16,7 +16,7 @@ dto Transaction:
     data?: bytes;
     version?: uint32;
     options?: uint32;
-    guardian?: string;
+    guardian?: Address;
 
     signature: bytes;
     guardianSignature?: bytes;

--- a/core/transactions-factories/account_transactions_factory.md
+++ b/core/transactions-factories/account_transactions_factory.md
@@ -7,21 +7,21 @@ class AccountTransactionsFactory:
     // "chainID", "minGasLimit", "gasLimitPerByte" etc.
 
     create_transaction_for_saving_key_value({
-        sender: IAddress;
+        sender: Address;
         key_value_pairs: Dict[bytes, bytes];
     }): Transaction;
 
     create_transaction_for_setting_guardian({
-        sender: IAddress;
-        guardian_address: IAddress;
+        sender: Address;
+        guardian_address: Address;
         service_id: string;
     }): Transaction;
 
     create_transaction_for_guarding_account({
-        sender: IAddress;
+        sender: Address;
     }): Transaction;
 
     create_transaction_for_unguarding_account({
-        sender: IAddress;
+        sender: Address;
     }): Transaction;
 ```

--- a/core/transactions-factories/delegation_transactions_factory.md
+++ b/core/transactions-factories/delegation_transactions_factory.md
@@ -7,115 +7,115 @@ class DelegationTransactionsFactory:
     // "minGasLimit", "gasLimitPerByte", gas limit for specific operations etc. (e.g. "gasLimitForStaking").
 
     create_transaction_for_new_delegation_contract({
-        sender: IAddress;
+        sender: Address;
         totalDelegationCap: Amount;
         service_fee: number;
         amount: Amount;
     }): Transaction;
 
     create_transaction_for_adding_nodes({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
         signedMessages: List[bytes];
     }): Transaction;
 
     create_transaction_for_removing_nodes({
-        sender: IAddress,
-        delegationContract: IAddress;
+        sender: Address,
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
     }): Transaction;
 
     create_transaction_for_staking_nodes({
-        sender: IAddress,
-        delegationContract: IAddress;
+        sender: Address,
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
     }): Transaction;
 
     create_transaction_for_unbonding_nodes({
-        sender: IAddress,
-        delegationContract: IAddress;
+        sender: Address,
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
     }): Transaction;
 
     create_transaction_for_unstaking_nodes({
-        sender: IAddress,
-        delegationContract: IAddress;
+        sender: Address,
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
     }): Transaction;
 
     create_transaction_for_unjailing_nodes({
-        sender: IAddress,
-        delegationContract: IAddress;
+        sender: Address,
+        delegationContract: Address;
         publicKeys: List[IPublicKey];
         amount: Amount;
     }): Transaction;
 
     create_transaction_for_changing_service_fee({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
         serviceFee: int;
     }): Transaction;
 
     create_transaction_for_modifying_delegation_cap({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
         delegationCap: int;
     }): Transaction;
 
     create_transaction_for_setting_automatic_activation({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_unsetting_automatic_activation({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_setting_cap_check_on_redelegate_rewards({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_unsetting_cap_check_on_redelegate_rewards({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_setting_metadata({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
         name: str;
         website: str;
         identifier: str;
     }): Transaction;
 
     create_transaction_for_delegating({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
         amount: Amount;
     }): Transaction;
 
     create_transaction_for_claiming_rewards({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_redelegating_rewards({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     create_transaction_for_undelegating({
-        sender: IAddress;
+        sender: Address;
         delegationContract: IAddres;
         amount: Amount;
     }): Transaction;
 
     create_transaction_for_withdrawing({
-        sender: IAddress;
-        delegationContract: IAddress;
+        sender: Address;
+        delegationContract: Address;
     }): Transaction;
 
     ...

--- a/core/transactions-factories/relayed_transactions_factory.md
+++ b/core/transactions-factories/relayed_transactions_factory.md
@@ -11,14 +11,14 @@ class RelayedTransactionsFactory:
 
     create_relayed_v1_transaction({
         inner_transaction: ITransaction;
-        relayer_address: IAddress;
+        relayer_address: Address;
     }): Transaction;
 
     // can throw InvalidInnerTransactionError if inner_transaction.gas_limit != 0
     create_relayed_v2_transaction({
         inner_transaction: ITransaction;
         inner_transaction_gas_limit: uint32;
-        relayer_address: IAddress;
+        relayer_address: Address;
     }): Transaction;
 
     // sets relayer's address as sender and receiver of the transaction
@@ -26,7 +26,7 @@ class RelayedTransactionsFactory:
     // can throw InvalidInnerTransactionError if one of the inner_transactions is also a relayed tranaction
     // does not set gasLimit
     create_relayed_v3_transaction({
-        relayer_addresss: IAddress;
+        relayer_addresss: Address;
         inner_transactions: List[ITransaction];
     }): Transaction;
 ```

--- a/core/transactions-factories/smart_contract_transactions_factory.md
+++ b/core/transactions-factories/smart_contract_transactions_factory.md
@@ -8,7 +8,7 @@ class SmartContractTransactionsFactory:
     // The constructor may also be parametrized with an `Abi` or `Codec` instance (implementation detail), necessary to encode contract call arguments.
 
     create_transaction_for_deploy({
-        sender: IAddress;
+        sender: Address;
         bytecode: bytes OR bytecodePath: Path;
         arguments: List[object] = [];
         native_transfer_amount: Amount = 0;
@@ -20,8 +20,8 @@ class SmartContractTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_execute({
-        sender: IAddress;
-        contract: IAddress;
+        sender: Address;
+        contract: Address;
         // If "function" is a reserved word in the implementing language, it should be replaced with a different name (e.g. "func" or "functionName").
         function: string;
         arguments: List[object] = [];
@@ -31,8 +31,8 @@ class SmartContractTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_upgrade({
-        sender: IAddress;
-        contract: IAddress;
+        sender: Address;
+        contract: Address;
         bytecode: bytes OR bytecodePath: Path;
         arguments: List[object] = [];
         native_transfer_amount: Amount = 0;
@@ -44,14 +44,14 @@ class SmartContractTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_claiming_developer_rewards({
-        sender: IAddress;
-        contract: IAddress;
+        sender: Address;
+        contract: Address;
     }): Transaction;
 
     create_transaction_for_changing_owner_address({
-        sender: IAddress;
-        contract: IAddress;
-        new_owner: IAddress;
+        sender: Address;
+        contract: Address;
+        new_owner: Address;
     }): Transaction;
 
 ```

--- a/core/transactions-factories/token_management_transactions_factory.md
+++ b/core/transactions-factories/token_management_transactions_factory.md
@@ -9,7 +9,7 @@ class TokenManagementTransactionsFactory:
     // "minGasLimit", "gasLimitPerByte", "issueCost", gas limit for specific operations etc. (e.g. "gasLimitForSettingSpecialRole").
 
     create_transaction_for_issuing_fungible({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         initialSupply: int;
@@ -24,7 +24,7 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_issuing_semi_fungible({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         canFreeze: boolean;
@@ -36,7 +36,7 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_issuing_non_fungible({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         canFreeze: boolean;
@@ -49,7 +49,7 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_registering_meta_esdt({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         numDecimals: number;
@@ -63,7 +63,7 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_registering_and_setting_roles({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         tokenType: RegisterAndSetAllRolesTokenType;
@@ -71,18 +71,18 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_setting_burn_role_globally({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_unsetting_burn_role_globally({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_setting_special_role_on_fungible_token({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
         addRoleLocalMint: boolean;
         addRoleLocalBurn: boolean;
@@ -90,8 +90,8 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_setting_special_role_on_semi_fungible_token({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
         addRoleNFTCreate?: boolean;
         addRoleNFTBurn?: boolean;
@@ -105,8 +105,8 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_setting_special_role_on_non_fungible_token({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
         addRoleNftCreate?: bool;
         addRoleNftBurn?: bool;
@@ -121,7 +121,7 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_creating_nft({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         initialQuantity: int;
         name: string;
@@ -132,61 +132,61 @@ class TokenManagementTransactionsFactory:
     }): Transaction;
 
     create_transaction_for_pausing({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_unpausing({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_freezing({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_unfreezing({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_wiping({
-        sender: IAddress;
-        user: IAddress;
+        sender: Address;
+        user: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     create_transaction_for_local_minting({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         supplyToMint: int;
     }): Transaction;
 
     create_transaction_for_local_burning({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         supplyToBurn: int;
     }): Transaction;
 
     create_transaction_for_updating_attributes({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
         attributes: bytes;
     }): Transaction;
 
     create_transaction_for_adding_quantity({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
         quantityToAdd: int;
     }): Transaction;
 
     create_transaction_for_burning_quantity({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
         quantityToBurn: int;
@@ -194,7 +194,7 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the same as the sender
     create_transaction_for_modifying_royalties({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
         new_royalties: int;
@@ -202,7 +202,7 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the same as the sender
     create_transaction_for_setting_new_uris({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
         new_uris: List[string];
@@ -210,14 +210,14 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the same as the sender
     create_transaction_for_modifying_creator({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenNonce: int;
     }): Transaction;
 
     // receiver is the same as the sender
     create_transaction_for_updating_metadata({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         new_tokenName?: string;
         new_royalties?: int;
@@ -228,7 +228,7 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the same as the sender
     create_transaction_for_metadata_recreate({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
         tokenName?: string;
         royalties?: int;
@@ -239,19 +239,19 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the esdt manager address
     create_transaction_for_changing_token_to_dynamic({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     // receiver is the esdt manager address
     create_transaction_for_updating_token_id({
-        sender: IAddress;
+        sender: Address;
         tokenIdentifier: string;
     }): Transaction;
 
     // receiver is the esdt manager address
     create_transaction_for_registering_dynamic_token({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         tokenType: "NFT" | "SFT" | "META" | "FNG";
@@ -259,7 +259,7 @@ class TokenManagementTransactionsFactory:
 
     // receiver is the esdt manager address
     create_transaction_for_registering_dynamic_and_setting_roles({
-        sender: IAddress;
+        sender: Address;
         tokenName: string;
         tokenTicker: string;
         tokenType: "NFT" | "SFT" | "META" | "FNG";

--- a/core/transactions-factories/transfer_transactions_factory.md
+++ b/core/transactions-factories/transfer_transactions_factory.md
@@ -10,16 +10,16 @@ class TransferTransactionsFactory:
 
     // If multiple transfers are specified, or if a native amount and a token transfer are specified, then a multi-ESDT transfer transaction should be created.
     create_transaction_for_transfer({
-        sender: IAddress;
-        receiver: IAddress;
+        sender: Address;
+        receiver: Address;
         native_amount: Optional[Amount];
         data: Optional[bytes];
         token_transfers: TokenTransfer[];
     }): Transaction;
 
     create_transaction_for_native_token_transfer({
-        sender: IAddress;
-        receiver: IAddress;
+        sender: Address;
+        receiver: Address;
         native_amount: Amount;
         data: Optional[bytes];
     }): Transaction;
@@ -30,8 +30,8 @@ class TransferTransactionsFactory:
     // If multiple transfers are specified, a multi-ESDT transfer transaction should be created.
     // Bad usage should be reported.
     create_transaction_for_esdt_token_transfer({
-        sender: IAddress;
-        receiver: IAddress;
+        sender: Address;
+        receiver: Address;
         token_transfers: TokenAmount[];
     }): Transaction;
 ```

--- a/entrypoints/account.md
+++ b/entrypoints/account.md
@@ -7,7 +7,7 @@ class Account:
     constructor(secret_key: bytes, hrp: Optional[str]);
     constructor(user_signer: IUserSigner, hrp: Optional[str]);
 
-    address: IAddress;
+    address: Address;
 
     // Local copy of the account nonce.
     // Must be explicitly managed by client code.

--- a/entrypoints/entrypoints.md
+++ b/entrypoints/entrypoints.md
@@ -30,7 +30,7 @@ class NetworkEntrypoint:
     verify_message_signature(message: Message): bool;
 
     // Fetches the account nonce from the network.
-    recall_account_nonce(address: IAddress): uint64;
+    recall_account_nonce(address: Address): uint64;
 
     // Signs the message and sets the signature field of the message
     def sign_message(self, message: Message, account: Account);

--- a/network-providers/basic/interface.md
+++ b/network-providers/basic/interface.md
@@ -16,19 +16,19 @@ interface IBasicNetworkProvider:
 
     // Fetches account information for a given address.
     // URL parameters can be used, for example, to provide block coordinates for deep-history lookups.
-    get_account(address: IAddress): AccountOnNetwork;
+    get_account(address: Address): AccountOnNetwork;
 
     // Fetches the storage (key-value pairs) of an account.
-    get_account_storage(address: IAddress): AccountStorage;
+    get_account_storage(address: Address): AccountStorage;
 
     // Fetches a specific storage entry of an account.
-    get_account_storage_entry(address: IAddress, entry_key: string): AccountStorageEntry;
+    get_account_storage_entry(address: Address, entry_key: string): AccountStorageEntry;
 
     // Waits until an account satisfies a given condition.
     // Can throw:
     // - ErrAwaitConditionNotReached
     await_account_on_condition(
-        address: IAddress,
+        address: Address,
         condition: [data: AccountOnNetwork] => boolean,
         options?: AwaitingOptions
     ): AccountOnNetwork;
@@ -70,15 +70,15 @@ interface IBasicNetworkProvider:
 
     // Fetches the balance of an account, for a given token.
     // Able to handle both fungible and non-fungible tokens (NFTs, SFTs, MetaESDTs).
-    get_token_of_account(address: IAddress, Token: token): TokenAmountOnNetwork;
+    get_token_of_account(address: Address, Token: token): TokenAmountOnNetwork;
 
     // Fetches the balances of an account, for all fungible tokens held by the account.
     // Pagination isn't explicitly handled by a basic network provider, but can be achieved by using `do_get_generic`.
-    get_fungible_tokens_of_account(address: IAddress): List[TokenAmountOnNetwork];
+    get_fungible_tokens_of_account(address: Address): List[TokenAmountOnNetwork];
 
     // Fetches the balances of an account, for all non-fungible tokens held by the account.
     // Pagination isn't explicitly handled by a basic network provider, but can be achieved by using `do_get_generic`.
-    get_non_fungible_tokens_of_account(address: IAddress): List[TokenAmountOnNetwork];
+    get_non_fungible_tokens_of_account(address: Address): List[TokenAmountOnNetwork];
 
     // Fetches the definition of a fungible token.
     get_definition_of_fungible_token(token_identifier: string): FungibleTokenMetadata;


### PR DESCRIPTION
 - Transaction sender and receiver should be of type `Address`.
 - Dropped `IAddress` - we can use the concrete primitive, `Address`.